### PR TITLE
Correct default value of `-d` in bulk mint guide

### DIFF
--- a/guides/nft/nft-bulk-mint.mdx
+++ b/guides/nft/nft-bulk-mint.mdx
@@ -477,7 +477,7 @@ Steps to convert the CSV file:
 
 3. Create the spend bundles. This command has six inputs:
   * `-w`: the wallet ID for the NFT wallet (`3` in this example)
-  * `-d`: a boolean indicating whether to use a DID (default is `True`)
+  * `-d`: a boolean indicating whether to use a DID (default is `False`)
   * `-a`: the royalty address for the NFTs (typically this is the artist's address)
   * `-r`: the royalty percentage, in basis points ("300" means 3%)
   * `-t`: a boolean indicating whether the target addresses are included in the metadata csv file (default is `False`)
@@ -582,7 +582,7 @@ Steps to convert the CSV file:
 3. Create the spend bundles. This command has six inputs:
 
   * `-w`: the wallet ID for the NFT wallet (`3` in this example)
-  * `-d`: a boolean indicating whether to use a DID (default is `True`)
+  * `-d`: a boolean indicating whether to use a DID (default is `False`)
   * `-a`: the royalty address for the NFTs (typically this is the artist's address)
   * `-r`: the royalty percentage, in basis points ("300" means 3%)
   * `-t`: a boolean indicating whether the target addresses are included in the metadata csv file (default is `False`; we'll use `True` for this example)


### PR DESCRIPTION
The default value for `mint_from_did` is `False`, but the guide mistakenly states it is `True`