### PR TITLE
The opc command does not return 2 values.

### DIFF
--- a/guides/chialisp-primer/first-smart-coin.md
+++ b/guides/chialisp-primer/first-smart-coin.md
@@ -84,13 +84,19 @@ We will now use these concepts and the `password.clsp` file you just wrote to cr
 Don't use a password that you use or plan to use for anything else, as this is not a secure smart coin. The most ideal choice for this is any number of random characters of your choice, such as `x7h2dDkE`. Just write it down for later.
 :::
 
-The first step is to curry the puzzle with the password's hash and get the puzzle hash and puzzle reveal:
+The first step is to curry the puzzle with the password's hash and get the puzzle hash:
 
 ```bash
 opc -H "$(cdv clsp curry password.clsp --args "$(run "(sha256 'password')")")"
 ```
 
-Write down both values this produces, the first one being the puzzle hash, and the second being the puzzle reveal.
+Then run the same command without the -H flag to get the puzzle reveal:
+
+```bash
+opc "$(cdv clsp curry password.clsp --args "$(run "(sha256 'password')")")"
+```
+
+Write down both values.
 
 You can convert the puzzle hash to an address and send funds to it like so:
 


### PR DESCRIPTION
While following this tutorial I noticed that opc command does not return 2 values as the tutorial said but rather needed to run the command 2 times, one with the -H flag and one without to get the puzzle hash and puzzle reveal. 

From the command --help:

  -H, --script-hash  Show only sha256 tree hash of program

Please feel free to re-word what I wrote in any way.